### PR TITLE
Feat/deactivate use unified topology

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@epsor/mongodb-wrapper",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epsor/mongodb-wrapper",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Mongodb wrapper",
   "main": "dist/index.js",
   "scripts": {

--- a/src/__mocks__/mongodb.js
+++ b/src/__mocks__/mongodb.js
@@ -1,6 +1,7 @@
 module.exports = {
   MongoClient: {
     connect: jest.fn(() => ({
+      on: jest.fn(),
       db: jest.fn(() => ({
         collection: jest.fn(),
         dropCollection: jest.fn(),

--- a/src/mongoWrapper.js
+++ b/src/mongoWrapper.js
@@ -20,13 +20,19 @@ export default class MongoWrapper {
 
   async connect(mongoDbUrl, db) {
     if (this.connected) {
-      return Promise.reject(new MongoError('Already connected.'));
+      throw new MongoError('Already connected.');
     }
 
     this.connection = await MongoClient.connect(mongoDbUrl, {
       useNewUrlParser: true,
-      useUnifiedTopology: true,
+      // useUnifiedTopology is causing timeout issues in some cases so we disable it for now
+      // See https://jira.mongodb.org/browse/NODE-2147 for updates on this issue
+      useUnifiedTopology: false,
     });
+    this.connection.on('error', err => {
+      throw err;
+    });
+
     this.db = this.connection.db(db);
     this.connected = true;
 


### PR DESCRIPTION
:warning: The `useUnifiedTopology` create some timeouts errors, however not using it is deprecated. 
See :
 - [Mongoose#8180](https://github.com/Automattic/mongoose/issues/8180)
 - And [NODE-2147](https://jira.mongodb.org/browse/NODE-2147)

#### Technical checklist

- [x] I tested my code following testing cases.
- [x] I covered my code with automatic tests.
- [x] I added logs in case of error or business logic.
- [x] I well designed my commits.
- [x] I read my Pull Request's changes.
- [x] I respected provided design and wording.
